### PR TITLE
Update LLMDiplomacy link

### DIFF
--- a/dev-web/nginx.conf
+++ b/dev-web/nginx.conf
@@ -20,8 +20,8 @@ server {
 
     # Fast path for everything under /diplomacy/
     location ^~ /diplomacy/ {
-        proxy_pass https://diplomacy.databookman.com$request_uri;
-        proxy_set_header Host              diplomacy.databookman.com;
+        proxy_pass https://llmdiplomacy.com$request_uri;
+        proxy_set_header Host              llmdiplomacy.com;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
         proxy_ssl_server_name on;

--- a/dev-web/public/services.json
+++ b/dev-web/public/services.json
@@ -115,7 +115,7 @@
   },
   {
     "name": "LLMDiplomacy",
-    "url": "/diplomacy/",
+    "url": "https://llmdiplomacy.com",
     "icon": "/llmdiplomacy_negative_favicon_1024.svg",
     "enabled": true
   },


### PR DESCRIPTION
## Summary
- switch LLMDiplomacy entry to `https://llmdiplomacy.com`
- proxy `/diplomacy/` traffic to the new host

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68502f408ebc832299a57971a51c9677