### PR TITLE
Fix llmdiplomacy CORS

### DIFF
--- a/dev-web/public/services.json
+++ b/dev-web/public/services.json
@@ -115,7 +115,7 @@
   },
   {
     "name": "LLMDiplomacy",
-    "url": "https://llmdiplomacy.com",
+    "url": "/diplomacy/",
     "icon": "/llmdiplomacy_negative_favicon_1024.svg",
     "enabled": true
   },


### PR DESCRIPTION
## Summary
- rewrite the LLMDiplomacy link to use the `/diplomacy/` proxy path

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6850cf61e8ac832285b5e74e59182676